### PR TITLE
[#53] 공통 컴포넌트 적용

### DIFF
--- a/src/app/signIn/page.tsx
+++ b/src/app/signIn/page.tsx
@@ -1,26 +1,30 @@
 import Image from "next/image";
+
+import Layout from "@/components/common/Layout";
 import LoginButton from "@/app/signIn/LoginButton";
 
 export default function SignIn() {
   return (
-    <div className="w-full h-full flex flex-col justify-between items-center">
-      <div className="pt-[10vh]">
-        <img
-          src="/assets/sub-logo.svg"
-          alt="클라이밍 갈 땐, 클라밍고와 함께해요!"
-          className="w-[25.6rem] h-[28rem]"
-        />
+    <Layout>
+      <div className="w-full h-full flex flex-col justify-between items-center">
+        <div className="pt-[10vh]">
+          <img
+            src="/assets/sub-logo.svg"
+            alt="클라이밍 갈 땐, 클라밍고와 함께해요!"
+            className="w-[25.6rem] h-[28rem]"
+          />
+        </div>
+        <div className="w-full flex flex-col justify-center items-center pb-[4vh]">
+          <Image
+            src="/assets/login-tooltip.png"
+            alt="소셜 계정으로 간편하게 시작하기"
+            width="224"
+            height="40"
+            className="animate-bounce"
+          />
+          <LoginButton />
+        </div>
       </div>
-      <div className="w-full flex flex-col justify-center items-center pb-[4vh]">
-        <Image
-          src="/assets/login-tooltip.png"
-          alt="소셜 계정으로 간편하게 시작하기"
-          width="224"
-          height="40"
-          className="animate-bounce"
-        />
-        <LoginButton />
-      </div>
-    </div>
+    </Layout>
   );
 }

--- a/src/app/signUp/SignUpForm.tsx
+++ b/src/app/signUp/SignUpForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import InputText from "@/components/common/InputText";
 import { signUpApi } from "@/api/modules/user";
 import { useUserActions, useUserValue } from "@/store/user";
+import BottomActionButton from "@/components/common/BottomActionButton";
 
 export default function SignUpForm() {
   const router = useRouter();
@@ -52,7 +53,7 @@ export default function SignUpForm() {
         ]}
         checkValid={checkValid}
       />
-      <button onClick={signUp}>완료</button>
+      <BottomActionButton onClick={signUp}>완료</BottomActionButton>
     </div>
   );
 }

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import Layout from "@/components/common/Layout";
 import NavigationHeader from "@/components/common/NavigationHeader";
 import SignUp from "@/app/signUp/SignUp";
@@ -5,7 +6,16 @@ import SignUp from "@/app/signUp/SignUp";
 export default function Page() {
   return (
     <Layout containHeader>
-      <NavigationHeader />
+      <NavigationHeader
+        pageTitle="회원가입"
+        hideBackButton
+        hideHomeButton
+        leftElement={
+          <Link href="/signIn">
+            <button className="text-shadow-dark">취소</button>
+          </Link>
+        }
+      />
       <SignUp />
     </Layout>
   );

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -1,5 +1,12 @@
+import Layout from "@/components/common/Layout";
+import NavigationHeader from "@/components/common/NavigationHeader";
 import SignUp from "@/app/signUp/SignUp";
 
 export default function Page() {
-  return <SignUp />;
+  return (
+    <Layout containHeader>
+      <NavigationHeader />
+      <SignUp />
+    </Layout>
+  );
 }

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -10,7 +10,7 @@ const Layout = ({
 }: PropsWithChildren<LayoutProps>) => {
   return (
     <main
-      className={`px-[2rem] ${containHeader ? "pt-[4.8rem]" : "pt-[2rem]"}`}
+      className={`w-full h-full px-[2rem] ${containHeader ? "pt-[4.8rem]" : "pt-[2rem]"}`}
     >
       {children}
     </main>

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -10,7 +10,7 @@ const Layout = ({
 }: PropsWithChildren<LayoutProps>) => {
   return (
     <main
-      className={`w-full h-full px-[2rem] ${containHeader ? "pt-[4.8rem]" : "pt-[2rem]"}`}
+      className={`w-full h-full px-[2rem] ${containHeader ? "pt-[5.6rem]" : "pt-[2rem]"}`}
     >
       {children}
     </main>

--- a/src/components/common/NavigationHeader.tsx
+++ b/src/components/common/NavigationHeader.tsx
@@ -29,7 +29,7 @@ const NavigationHeader = ({
       </div>
 
       {/** center */}
-      <h2 className="text-center text-base font-medium flex-grow">
+      <h2 className="text-center text-base font-medium flex-grow self-center px-[2rem]">
         {pageTitle}
       </h2>
 
@@ -49,7 +49,7 @@ const BackButton = () => {
   const goPrev = () => router.back();
 
   return (
-    <button className="pl-[-1rem] py-[0.8rem]" onClick={goPrev}>
+    <button className="ml-[-1rem] py-[0.8rem] flex-shrink-0" onClick={goPrev}>
       <img src="/icons/icon-back.svg" alt="뒤로 가기" width="24" height="24" />
     </button>
   );
@@ -57,7 +57,7 @@ const BackButton = () => {
 
 const HomeButton = () => {
   return (
-    <Link href="/">
+    <Link href="/" className="flex-shrink-0">
       <button className="py-[0.8rem]">
         <img
           src="/icons/icon-home.svg"

--- a/src/components/common/NavigationHeader.tsx
+++ b/src/components/common/NavigationHeader.tsx
@@ -8,6 +8,7 @@ type NavigationHeaderProps = {
   pageTitle?: string;
   hideBackButton?: boolean;
   hideHomeButton?: boolean;
+  leftElement?: React.ReactNode;
   rightElement?: React.ReactNode;
 };
 
@@ -15,14 +16,16 @@ const NavigationHeader = ({
   pageTitle,
   hideBackButton = false,
   hideHomeButton = false,
+  leftElement,
   rightElement,
 }: NavigationHeaderProps) => {
   return (
-    <nav className="h-[4.8rem] fixed top-0 left-0 flex items-center justify-between w-screen z-[300] overflow-y-hidden bg-white">
+    <nav className="h-[5.6rem] fixed top-0 left-0 flex items-center justify-between w-screen z-[300] overflow-y-hidden bg-white">
       {/** left */}
-      <div className="flex px-[0.2rem] basis-[10rem] gap-[0.4rem] items-center">
+      <div className="flex px-[2rem]  basis-[10rem] gap-[0.4rem] items-center">
         {!hideBackButton && <BackButton />}
         {!hideHomeButton && <HomeButton />}
+        {leftElement}
       </div>
 
       {/** center */}
@@ -46,7 +49,7 @@ const BackButton = () => {
   const goPrev = () => router.back();
 
   return (
-    <button className="pl-[0.8rem] py-[0.8rem]" onClick={goPrev}>
+    <button className="pl-[-1rem] py-[0.8rem]" onClick={goPrev}>
       <img src="/icons/icon-back.svg" alt="뒤로 가기" width="24" height="24" />
     </button>
   );


### PR DESCRIPTION
## 구현한 내용
- Layout 컴포넌트에 'w-full h-full' 스타일 추가했어요.
- 회원가입 페이지에서 헤더 왼쪽에 취소 버튼을 필요해서 `NavigationHeader` 컴포넌트에 leftElement prop을 추가했어요.
<img width="300" alt="스크린샷 2024-05-15 오후 8 13 37" src="https://github.com/SingTheCode/climingo-client/assets/57716832/55c54ed8-2b93-41aa-9dc5-96e389fefd87">

## 공유할 내용
- 다른 의견이나 컴포넌트 수정으로 인해 걱정되는 사이드이펙트가 있으시면 말씀해주세요!

## 관련된 이슈
- Close #53 