### PR TITLE
[#65] local 개발환경에 https, hostname 추가된 스크립트 작성

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -H local.climingo.vercel.app",
+    "dev:https": "next dev -H local.climingo.vercel.app --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -H local.climingo.vercel.app",
-    "dev:https": "next dev -H local.climingo.vercel.app --experimental-https",
+    "dev": "next dev -H local.dev-climingo.vercel.app --experimental-https",
+    "stg": "next dev -H local.stg-climingo.vercel.app --experimental-https",
+    "prd": "next dev -H local.climingo.vercel.app --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## 구현한 내용
- `local.climingo.vercel.app`으로 개발서버가 실행되도록 추가했어요.
- `dev:https` 스크립트를 추가했어요.

## 공유할 내용
- /etc/hosts 파일에 `127.0.0.1 local.climingo.vercel.app` 을 추가한 후에 실행해주세요.
- 수정할 부분 있으면 말씀해주세요!

## 관련된 이슈
- Close #65 