### PR TITLE
[#64] [QA] 기록하기 헤더 타이틀이 깨지는 현상

### DIFF
--- a/src/components/common/LayerPopup.tsx
+++ b/src/components/common/LayerPopup.tsx
@@ -73,29 +73,31 @@ const LayerPopupRoot = ({
   );
 };
 
-const LayerPopupHeader = ({ children }: { children?: React.ReactNode }) => {
+const LayerPopupHeader = ({
+  title,
+  children,
+}: {
+  title?: string;
+  children?: React.ReactNode;
+}) => {
   return (
-    <div className="flex justify-between items-center px-6 sm:px-8 pl-14">
+    <div className="flex items-center justify-end px-8 min-h-[2.4rem]">
+      {title && (
+        <DialogTitle className="absolute left-1/2 -translate-x-1/2 text-center text-base font-medium leading-6 max-w-[80%] truncate">
+          {title}
+        </DialogTitle>
+      )}
       {children}
     </div>
   );
 };
 
-const LayerPopupTitle = ({ children }: { children?: React.ReactNode }) => {
-  return (
-    <DialogTitle className="text-base font-semibold leading-6 m-auto">
-      {children}
-    </DialogTitle>
-  );
-};
-
 const LayerPopupBody = ({ children }: { children?: React.ReactNode }) => {
-  return <div className="relative mt-6 flex-1 px-6 sm:px-8 ">{children}</div>;
+  return <div className="relative mt-6 flex-1 px-8 ">{children}</div>;
 };
 
 const LayerPopup = Object.assign(LayerPopupRoot, {
   Header: LayerPopupHeader,
-  Title: LayerPopupTitle,
   Body: LayerPopupBody,
 });
 
@@ -105,7 +107,7 @@ const CloseButton = (props: InputHTMLAttributes<HTMLButtonElement>) => (
   <button
     {...props}
     type="button"
-    className="absolute left-6 sm:left-8 top-5 rounded-md focus:outline-none focus:ring-2 focus:ring-white"
+    className="absolute left-6 top-6 rounded-md focus:outline-none focus:ring-2 focus:ring-white"
   >
     <Image width="24" height="24" src="/icons/icon-close.svg" alt="close" />
   </button>

--- a/src/components/common/LayerPopup.tsx
+++ b/src/components/common/LayerPopup.tsx
@@ -83,7 +83,7 @@ const LayerPopupHeader = ({
   return (
     <div className="flex items-center justify-end px-8 min-h-[2.4rem]">
       {title && (
-        <DialogTitle className="absolute left-1/2 -translate-x-1/2 text-center text-base font-medium leading-6 max-w-[80%] truncate">
+        <DialogTitle className="absolute left-1/2 -translate-x-1/2 text-center text-base font-medium leading-6 w-[60%] line-clamp-2 break-keep">
           {title}
         </DialogTitle>
       )}

--- a/src/components/common/NavigationHeader.tsx
+++ b/src/components/common/NavigationHeader.tsx
@@ -29,7 +29,7 @@ const NavigationHeader = ({
       </div>
 
       {/** center */}
-      <h2 className="text-center text-base font-medium self-center px-[2rem] flex-shrink-0 max-w-[80%] truncate">
+      <h2 className="absolute left-1/2 -translate-x-1/2 text-center text-base font-medium self-center px-[2rem] flex-shrink-0 max-w-[80%] truncate">
         {pageTitle}
       </h2>
 

--- a/src/components/common/NavigationHeader.tsx
+++ b/src/components/common/NavigationHeader.tsx
@@ -29,7 +29,7 @@ const NavigationHeader = ({
       </div>
 
       {/** center */}
-      <h2 className="absolute left-1/2 -translate-x-1/2 text-center text-base font-medium self-center px-[2rem] flex-shrink-0 max-w-[80%] truncate">
+      <h2 className="absolute left-1/2 -translate-x-1/2 text-center text-base font-medium self-center px-[2rem] flex-shrink-0 w-[60%] line-clamp-2 break-keep">
         {pageTitle}
       </h2>
 

--- a/src/components/record/FilterSection.tsx
+++ b/src/components/record/FilterSection.tsx
@@ -15,7 +15,6 @@ import { ClimbingPlace } from "@/types/common";
 
 import LevelIcon from "@/components/common/LevelIcon";
 import LayerPopup from "@/components/common/LayerPopup";
-import Layout from "@/components/common/Layout";
 import Place from "@/components/place/Place";
 
 interface SelectedLevel {
@@ -188,9 +187,10 @@ export default function FilterSection({
         open={isPopupOpen}
         onClose={() => setIsPopupOpen(false)}
       >
-        <Layout containHeader>
+        <LayerPopup.Header title="암장 검색하기" />
+        <LayerPopup.Body>
           <Place onSearchedPlaceClick={selectPlace} />
-        </Layout>
+        </LayerPopup.Body>
       </LayerPopup>
     </section>
   );

--- a/src/components/record/SelectPlaceWithLevel.tsx
+++ b/src/components/record/SelectPlaceWithLevel.tsx
@@ -8,7 +8,6 @@ import { Level } from "@/types/record";
 import useGetLevelsQuery from "@/hooks/place/useGetLevelsQuery";
 
 import LayerPopup from "@/components/common/LayerPopup";
-import Layout from "@/components/common/Layout";
 import SearchPlace from "@/components/place/Place";
 import ClearButton from "@/components/record/ClearButton";
 import { Heading, Placeholder } from "@/components/record/commonText";
@@ -47,9 +46,10 @@ const SelectPlaceWithLevel = memo(
             onClear={resetAll}
           />
           <LayerPopup open={open} onClose={() => setOpen(false)} fullscreen>
-            <Layout>
+            <LayerPopup.Header title="암장 검색하기" />
+            <LayerPopup.Body>
               <SearchPlace onSearchedPlaceClick={handlePlaceSelect} />
-            </Layout>
+            </LayerPopup.Body>
           </LayerPopup>
         </div>
         <div className="flex flex-col gap-[1.4rem]">


### PR DESCRIPTION
## 구현한 내용
- NavigationHeader와 LayouerPopup.Header 컴포넌트의 전체적인 스타일을 맞췄어요.
- max-w-[80%] 속성 적용 후 가운데 정렬을 통해 title이 깨지는 현상을 해결했어요.
  - 80% 이상인 타이틀은 말줄임 표시가 적용돼요.

## 공유할 내용
- 레이어 팝업이 필요한 페이지를 작업하다가 LayerPopup Header 또한 스타일 수정이 필요해보여서 부득이하게 함께 작업했어요. 양해 부탁드립니다..🙏🏻

## 관련된 이슈
- close #64 