### PR TITLE
[#120] feat: scope에 name, email 추가

### DIFF
--- a/src/components/auth/AppleLogin.tsx
+++ b/src/components/auth/AppleLogin.tsx
@@ -12,7 +12,8 @@ export default function AppleLogin() {
   const login = async () => {
     window.AppleID.auth.init({
       clientId: "com.climingo.app",
-      redirectURI: `${window.location.origin}/oauth`,
+      redirectURI: `${window.location.origin}/signIn`,
+      scope: "name email",
       usePopup: true,
     });
 


### PR DESCRIPTION
## 구현한 내용
name, email 정보를 애플계정으로부터 받아오도록 scope를 추가하였습니다.

## 공유할 내용
- redirect url path를 /oauth에서 /signIn으로 변경하였습니다.
## 관련된 이슈
