### PR TITLE
[#128] 애플로그인인 경우 회원가입/로그인 로직 구현

### DIFF
--- a/src/components/auth/AppleLogin.tsx
+++ b/src/components/auth/AppleLogin.tsx
@@ -19,7 +19,7 @@ export default function AppleLogin() {
 
     try {
       const res = await window.AppleID.auth.signIn();
-      await signIn(res.authorization.id_token, res.user);
+      await signIn(res.authorization.code, res.user);
     } catch (error) {
       if (error instanceof Error) {
         if (error.message) {

--- a/src/components/auth/AppleLogin.tsx
+++ b/src/components/auth/AppleLogin.tsx
@@ -12,7 +12,7 @@ export default function AppleLogin() {
   const login = async () => {
     window.AppleID.auth.init({
       clientId: "com.climingo.app",
-      redirectURI: `${window.location.origin}/signIn`,
+      redirectURI: `${window.location.origin}/oauth`,
       scope: "name email",
       usePopup: true,
     });

--- a/src/components/auth/AppleLogin.tsx
+++ b/src/components/auth/AppleLogin.tsx
@@ -19,7 +19,7 @@ export default function AppleLogin() {
 
     try {
       const res = await window.AppleID.auth.signIn();
-      await signIn(res.authorization.code, res.user);
+      await signIn(res.authorization.code, "apple", res.user);
     } catch (error) {
       if (error instanceof Error) {
         if (error.message) {

--- a/src/components/auth/AppleLogin.tsx
+++ b/src/components/auth/AppleLogin.tsx
@@ -19,7 +19,7 @@ export default function AppleLogin() {
 
     try {
       const res = await window.AppleID.auth.signIn();
-      signIn(res.authorization.id_token);
+      await signIn(res.authorization.id_token, res.user);
     } catch (error) {
       if (error instanceof Error) {
         if (error.message) {

--- a/src/components/auth/OAuth.tsx
+++ b/src/components/auth/OAuth.tsx
@@ -13,7 +13,7 @@ export default function OAuth() {
 
   useRunOnce(() => {
     const fetch = async () => {
-      signIn(code).catch((err) => {
+      signIn(code, "kakao").catch((err) => {
         if (err instanceof Error) {
           if (err.message) {
             alert(err.message);

--- a/src/components/auth/OAuth.tsx
+++ b/src/components/auth/OAuth.tsx
@@ -9,20 +9,18 @@ export default function OAuth() {
   const router = useRouter();
   const { signIn } = useAuth();
 
-  const code = useSearchParams().get("code") || "";
+  const code = useSearchParams().get("code") ?? "";
 
   useRunOnce(() => {
     const fetch = async () => {
-      try {
-        signIn(code);
-      } catch (err) {
+      signIn(code).catch((err) => {
         if (err instanceof Error) {
           if (err.message) {
             alert(err.message);
           }
           router.replace("/signIn");
         }
-      }
+      });
     };
 
     fetch();

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -1,10 +1,21 @@
+"use client";
+
+import { useUserValue } from "@/store/user";
+
 import SignUpForm from "@/components/auth/SignUpForm";
 import Avatar from "@/components/common/Avatar";
 
 export default function SignUp() {
+  const user = useUserValue();
+
+  const boulderColors = ["blue", "green", "yellow", "red"];
+  const profileUrl =
+    user?.profileUrl ??
+    `/assets/${boulderColors[Math.floor(Math.random() * 4)]}-boulder.svg`;
+
   return (
     <div className="w-full h-full flex flex-col items-center">
-      <Avatar size="lg" src="/assets/green-boulder.svg" alt="green boulder" />
+      <Avatar size="lg" src={profileUrl} alt="green boulder" />
       <SignUpForm />
     </div>
   );

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -46,7 +46,7 @@ export default function SignUpForm() {
   };
 
   useEffect(() => {
-    if (user) {
+    if (user?.nickname) {
       setNickname(user.nickname);
     }
   }, [user]);

--- a/src/components/profile/MyProfile.tsx
+++ b/src/components/profile/MyProfile.tsx
@@ -45,7 +45,9 @@ const MyShortProfile = () => {
 
   return (
     <div className="flex items-center gap-[1.5rem]">
-      <Avatar src={data.profileUrl} size="base" alt="profile" priority />
+      {data.profileUrl && (
+        <Avatar src={data.profileUrl} size="base" alt="profile" priority />
+      )}
       <p className="text-xl font-bold line-clamp-2">{data.nickname}</p>
       <Link href="/myProfile/detail" className="-ml-[1rem] shrink-0">
         <Image

--- a/src/components/profile/MyProfileDetail.tsx
+++ b/src/components/profile/MyProfileDetail.tsx
@@ -25,7 +25,7 @@ const MyProfileDetail = () => {
       <EditableProfile
         memberId={data.memberId}
         nickname={data.nickname}
-        profileUrl={data.profileUrl}
+        profileUrl={data?.profileUrl}
       />
       <DetailMemberInfo
         oAuth={{
@@ -42,7 +42,7 @@ export default MyProfileDetail;
 interface EditableProfileProps {
   memberId: number;
   nickname: string;
-  profileUrl: string;
+  profileUrl?: string;
 }
 
 const EditableProfile = ({
@@ -88,7 +88,9 @@ const EditableProfile = ({
 
   return (
     <section className="flex flex-col items-center gap-[1.5rem]">
-      <Avatar size="lg" alt="profile-avatar" src={profileUrl} priority />
+      {profileUrl && (
+        <Avatar size="lg" alt="profile-avatar" src={profileUrl} priority />
+      )}
 
       <div className="flex gap-[0.2rem] relative -right-[0.5rem]">
         <p className="text-xl font-bold">{nickname}</p>
@@ -108,13 +110,15 @@ const EditableProfile = ({
         </LayerPopup.Header>
         <LayerPopup.Body>
           <div className="flex flex-col py-[2rem] gap-[2rem]">
-            <Avatar
-              size="lg"
-              alt="profile-avatar"
-              src={profileUrl}
-              className="rounded-full self-center"
-              priority
-            />
+            {profileUrl && (
+              <Avatar
+                size="lg"
+                alt="profile-avatar"
+                src={profileUrl}
+                className="rounded-full self-center"
+                priority
+              />
+            )}
             <div className="relative flex flex-col gap-[0.5rem]">
               <h3>닉네임</h3>
               <InputText

--- a/src/components/profile/MyProfileDetail.tsx
+++ b/src/components/profile/MyProfileDetail.tsx
@@ -25,7 +25,7 @@ const MyProfileDetail = () => {
       <EditableProfile
         memberId={data.memberId}
         nickname={data.nickname}
-        profileUrl={data?.profileUrl}
+        profileUrl={data.profileUrl}
       />
       <DetailMemberInfo
         oAuth={{

--- a/src/hooks/auth/index.ts
+++ b/src/hooks/auth/index.ts
@@ -1,6 +1,6 @@
 import { useRouter } from "next/navigation";
 
-import { OAuthApiRequest } from "@/types/auth";
+import { OAuthApiRequest, SignInResponse } from "@/types/auth";
 import { oAuthApi, signInApi } from "@/api/modules/user";
 import { useUserActions } from "@/store/user";
 import useAuthSession from "@/hooks/useAuthStorage";
@@ -11,7 +11,7 @@ export const useAuth = () => {
   const { setUser } = useUserActions();
   const authSession = useAuthSession();
 
-  const signIn = async (token: string) => {
+  const signIn = async (token: string, user?: SignInResponse["user"]) => {
     const params: OAuthApiRequest = {
       providerType: "apple",
       redirectUri: `${window.location.origin}/oauth`,
@@ -31,7 +31,12 @@ export const useAuth = () => {
       router.push("/");
       return;
     }
-    setUser(memberInfo);
+
+    if (user) {
+      setUser({ ...memberInfo, email: user.email, nickname: user.name });
+    } else {
+      setUser(memberInfo);
+    }
     router.push("/signUp");
   };
   return { signIn };

--- a/src/hooks/auth/index.ts
+++ b/src/hooks/auth/index.ts
@@ -1,6 +1,6 @@
 import { useRouter } from "next/navigation";
 
-import { OAuthApiRequest, SignInResponse } from "@/types/auth";
+import { OAuthApiRequest, OAuthProvider, SignInResponse } from "@/types/auth";
 import { oAuthApi, signInApi } from "@/api/modules/user";
 import { useUserActions } from "@/store/user";
 import useAuthSession from "@/hooks/useAuthStorage";
@@ -11,9 +11,13 @@ export const useAuth = () => {
   const { setUser } = useUserActions();
   const authSession = useAuthSession();
 
-  const signIn = async (token: string, user?: SignInResponse["user"]) => {
+  const signIn = async (
+    token: string,
+    providerType: OAuthProvider,
+    user?: SignInResponse["user"]
+  ) => {
     const params: OAuthApiRequest = {
-      providerType: "apple",
+      providerType,
       redirectUri: `${window.location.origin}/oauth`,
       code: token,
     } as const;

--- a/src/hooks/auth/index.ts
+++ b/src/hooks/auth/index.ts
@@ -33,7 +33,11 @@ export const useAuth = () => {
     }
 
     if (user) {
-      setUser({ ...memberInfo, email: user.email, nickname: user.name });
+      setUser({
+        ...memberInfo,
+        email: user.email,
+        nickname: user.name.lastName + user.name.firstName,
+      });
     } else {
       setUser(memberInfo);
     }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -45,7 +45,7 @@ interface Authorization {
 
 export interface SignInResponse {
   authorization: Authorization;
-  user?: { email: string; name: string };
+  user?: { email: string; name: { firstName: string; lastName: string } };
 }
 
 declare global {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -43,7 +43,7 @@ interface Authorization {
   state?: string;
 }
 
-interface SigninResponse {
+export interface SignInResponse {
   authorization: Authorization;
   user?: { email: string; name: string };
 }
@@ -53,7 +53,7 @@ declare global {
     AppleID: {
       auth: {
         init: (config: ClientConfig) => void;
-        signIn: (config?: ClientConfig) => Promise<SigninResponse>;
+        signIn: (config?: ClientConfig) => Promise<SignInResponse>;
       };
     };
   }


### PR DESCRIPTION
## 구현한 내용
애플 로그인 최초 인증 시 user 정보를 응답받게 되는데, user 정보가 있다면, pAuthApi의 memberInfo 정보 대신 apple user 정보를 회원가입 페이지로 넘겨준다.

## 공유할 내용

## 관련된 이슈
