### PR TITLE
[#139] 회원가입 버튼 연속 클릭 방지하기

### DIFF
--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -26,7 +26,7 @@ export default function SignUpForm() {
   };
 
   const signUp = async () => {
-    if (!isValid) {
+    if (!isValid || nickname === "") {
       alert("닉네임이 유효하지 않습니다. 다시 입력해주세요.");
       setNickname("");
       return;

--- a/src/components/common/BottomActionButton.tsx
+++ b/src/components/common/BottomActionButton.tsx
@@ -1,13 +1,37 @@
-import { ButtonHTMLAttributes, PropsWithChildren } from "react";
+"use client";
+
+import {
+  ButtonHTMLAttributes,
+  MouseEvent,
+  PropsWithChildren,
+  useState,
+} from "react";
+import { flushSync } from "react-dom";
 
 const BottomActionButton = ({
   children,
+  onClick,
   ...props
 }: PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>) => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleButtonClick = async (event: MouseEvent<HTMLButtonElement>) => {
+    if (isLoading) {
+      return;
+    }
+
+    // 로딩 상태를 동기적으로(즉시) UI에 반영하기 위해 flushSync 사용
+    flushSync(() => setIsLoading(true));
+    await onClick?.(event);
+    setIsLoading(false);
+  };
+
   return (
     <div className="fixed inset-x-0 bottom-0 p-[2rem] pt-[0.5rem] bg-white shadow-white-top">
       <button
         className="w-full h-[4.8rem] font-bold rounded-[1rem] bg-primary text-white hover:bg-primary/90 disabled:bg-shadow-light"
+        disabled={isLoading}
+        onClick={handleButtonClick}
         {...props}
       >
         {children}


### PR DESCRIPTION
## 구현한 내용
- `BottomActionButton`에 loading 상태를 추가했어요.
  - 클릭 이벤트가 발생하면 즉시 loading 상태가 변경되어 버튼이 disabled 상태로 바뀌어요.
- 닉네임을 작성하지 않은 경우에도 회원가입 api 호출이 발생하고 있어서 이를 수정했어요

## 관련된 이슈
- Close #139 