### PR TITLE
[#141] 프로필이 없는 경우 회원가입 시 default profile url 추가

### DIFF
--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -1,10 +1,21 @@
+"use client";
+
 import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { useUserValue } from "@/store/user";
 
 import Layout from "@/components/common/Layout";
 import NavigationHeader from "@/components/common/NavigationHeader";
 import SignUp from "@/components/auth/SignUp";
 
 export default function Page() {
+  const memberInfo = useUserValue();
+
+  if (memberInfo === null) {
+    return notFound();
+  }
+
   return (
     <Layout containHeader>
       <NavigationHeader

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -1,21 +1,22 @@
 "use client";
 
+import type { MemberInfo } from "@/types/auth";
+
 import { useUserValue } from "@/store/user";
-import { getProfileUrl } from "@/hooks/auth";
 
 import SignUpForm from "@/components/auth/SignUpForm";
 import Avatar from "@/components/common/Avatar";
 
+/**
+ * SignUp 페이지에서 전역 user state가 있는 경우에만 해당 컴포넌트 렌더링
+ * 참고 - app/signUp/page.tsx
+ */
 export default function SignUp() {
-  const user = useUserValue();
+  const { profileUrl } = useUserValue() as MemberInfo;
 
   return (
     <div className="w-full h-full flex flex-col items-center">
-      <Avatar
-        size="lg"
-        src={getProfileUrl(user?.profileUrl)}
-        alt="green boulder"
-      />
+      <Avatar size="lg" src={profileUrl} alt="profile" />
       <SignUpForm />
     </div>
   );

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
+import type { MemberInfo } from "@/types/auth";
+
 import { signUpApi } from "@/api/modules/user";
 import { useUserActions, useUserValue } from "@/store/user";
 import useAuthSession from "@/hooks/useAuthStorage";
@@ -10,10 +12,13 @@ import useAuthSession from "@/hooks/useAuthStorage";
 import InputText from "@/components/common/InputText";
 import BottomActionButton from "@/components/common/BottomActionButton";
 
+/**
+ * 전역 user state가 있는 경우에만 해당 컴포넌트 렌더링
+ */
 export default function SignUpForm() {
   const router = useRouter();
 
-  const user = useUserValue();
+  const user = useUserValue() as MemberInfo;
   const { setUser } = useUserActions();
 
   const authSession = useAuthSession();
@@ -33,12 +38,10 @@ export default function SignUpForm() {
     }
 
     try {
-      if (user) {
-        const data = await signUpApi({ ...user, nickname });
-        setUser(data);
-        authSession.set(data);
-        router.replace("/");
-      }
+      const data = await signUpApi({ ...user, nickname });
+      setUser(data);
+      authSession.set(data);
+      router.replace("/");
     } catch {
       alert("로그인에 실패했습니다.");
       router.replace("/signIn");
@@ -52,23 +55,26 @@ export default function SignUpForm() {
   }, [user]);
 
   return (
-    <div className="w-full flex flex-col items-start pt-[2rem]">
-      <span>닉네임</span>
-      <InputText
-        value={nickname}
-        setText={setNickname}
-        maxLength={8}
-        rules={[
-          (value) =>
-            /^[a-zA-Z0-9가-힣]+$/.test(value) ||
-            "띄어쓰기 없이 영문,숫자,한글만 가능해요",
-          (value) =>
-            (2 <= value.length && value.length <= 8) ||
-            "2글자 이상 8글자 이하만 가능해요",
-        ]}
-        checkValid={checkValid}
-      />
+    <>
+      <div className="w-full flex flex-col items-start pt-[2rem]">
+        <span>닉네임</span>
+        <InputText
+          value={nickname}
+          setText={setNickname}
+          maxLength={8}
+          rules={[
+            (value) =>
+              /^[a-zA-Z0-9가-힣]+$/.test(value) ||
+              "띄어쓰기 없이 영문,숫자,한글만 가능해요",
+            (value) =>
+              (2 <= value.length && value.length <= 8) ||
+              "2글자 이상 8글자 이하만 가능해요",
+          ]}
+          checkValid={checkValid}
+        />
+      </div>
+
       <BottomActionButton onClick={signUp}>완료</BottomActionButton>
-    </div>
+    </>
   );
 }

--- a/src/components/record/RecordItem.tsx
+++ b/src/components/record/RecordItem.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 
 import type { RecordMetadata } from "@/types/record";
 import { fromNowFormat } from "@/utils/common";
-import { getProfileUrl } from "@/hooks/auth";
 
 import LevelIcon from "@/components/common/LevelIcon";
 import Avatar from "@/components/common/Avatar";
@@ -64,11 +63,7 @@ export default function RecordItem({
         >
           {shouldRenderMemberInfo && (
             <>
-              <Avatar
-                src={getProfileUrl(memberInfo.profileUrl)}
-                size="xs"
-                alt="profile"
-              />
+              <Avatar src={memberInfo.profileUrl} size="xs" alt="profile" />
               <span className="text-white text-xs flex-grow truncate">
                 {memberInfo.nickname}
               </span>

--- a/src/hooks/auth/index.ts
+++ b/src/hooks/auth/index.ts
@@ -23,7 +23,7 @@ export const useAuth = () => {
     } as const;
     const { registered, memberInfo } = await oAuthApi(params);
 
-    const defaultProfileUrl = getProfileUrl(memberInfo.profileUrl);
+    const defaultProfileUrl = getDefaultProfileUrl(memberInfo.profileUrl);
 
     if (registered) {
       const data = await signInApi({
@@ -56,7 +56,7 @@ export const useAuth = () => {
   return { signIn };
 };
 
-export const getProfileUrl = (profileUrl?: string) => {
+export const getDefaultProfileUrl = (profileUrl?: string) => {
   const boulderColors = ["blue", "green", "yellow", "red"];
 
   return (

--- a/src/hooks/auth/index.ts
+++ b/src/hooks/auth/index.ts
@@ -23,6 +23,8 @@ export const useAuth = () => {
     } as const;
     const { registered, memberInfo } = await oAuthApi(params);
 
+    const defaultProfileUrl = getProfileUrl(memberInfo.profileUrl);
+
     if (registered) {
       const data = await signInApi({
         providerType: memberInfo.providerType!,
@@ -41,9 +43,13 @@ export const useAuth = () => {
         ...memberInfo,
         email: user.email,
         nickname: user.name.lastName + user.name.firstName,
+        profileUrl: defaultProfileUrl,
       });
     } else {
-      setUser(memberInfo);
+      setUser({
+        ...memberInfo,
+        profileUrl: defaultProfileUrl,
+      });
     }
     router.push("/signUp");
   };


### PR DESCRIPTION
## 구현한 내용
- Oauth 페이지에서 SignUp 페이지로 이동하기 전 호출되는 `useAuth` 훅에서 사용자의 프로필 이미지가 없는 경우 랜덤하게 default profile url을 설정하도록 수정했어요.

## 관련된 이슈
- close #141 