### PR TITLE
[#138] fix: 비디오 파일 확장자와 MIME 타입의 video/확장자 패턴이 일치하지 않는 경우 해결

### DIFF
--- a/src/components/record/CreateRecordForm.tsx
+++ b/src/components/record/CreateRecordForm.tsx
@@ -43,10 +43,17 @@ const CreateRecordForm = () => {
 
     try {
       setIsPending(true);
-      const { presignedUrl, videoUrl } = await getPresignedUrlApi({
-        fileName: formValues.video.name.split(".")[0],
-        extension: formValues.video.type.split("/")[1],
-      });
+
+      const splitFileNameExtension = (params: string) => {
+        const lastDotIdx = params.lastIndexOf(".");
+        const fileName = params.slice(0, lastDotIdx);
+        const extension = params.slice(lastDotIdx + 1);
+
+        return { fileName, extension };
+      };
+      const { presignedUrl, videoUrl } = await getPresignedUrlApi(
+        splitFileNameExtension(formValues.video.name)
+      );
       await uploadVideoApi({
         presignedUrl,
         file: formValues.video,


### PR DESCRIPTION
## 구현한 내용
파일 확장자와 extension 타입이 다른 케이스가 있어, 파일 이름에서 마지막 `.`을 기준으로 파일이름과 확장자를 구분하였습니다.

## 관련된 이슈
#138 