### PR TITLE
[#157] 기록 생성 페이지 유의문구 가려지는 문제 해결

### DIFF
--- a/src/components/record/CreateRecordForm.tsx
+++ b/src/components/record/CreateRecordForm.tsx
@@ -77,7 +77,7 @@ const CreateRecordForm = () => {
 
   return (
     <form
-      className="flex flex-col gap-[3rem] pt-[2rem]"
+      className="flex flex-col gap-[3rem] pt-[2rem] pb-[10rem]"
       onSubmit={handleFormSubmit}
     >
       <SelectPlaceWithLevel


### PR DESCRIPTION
## 구현한 내용
유의의사항 문구가 가려지지 않도록 하단에 패딩을 추가했습니다.

<img width="300" alt="스크린샷 2025-04-22 오후 7 26 58" src="https://github.com/user-attachments/assets/8cfc656c-dcc5-4997-af43-7644f6e5b341" />

## 공유할 내용

## 관련된 이슈
- close #157 