### PR TITLE
[#154] 인가되지 않은 사용자의 경우 로그인 페이지로 이동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ next-env.d.ts
  # IntelliJ IDEA
 /.idea/
 *.iml
+
+# Cursor
+.cursor

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.29.0",
         "axios": "^1.6.8",
         "dayjs": "^1.11.11",
+        "mitt": "^3.0.1",
         "next": "14.1.1",
         "react": "^18",
         "react-dom": "^18"
@@ -4112,6 +4113,11 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "node_modules/ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query": "^5.29.0",
     "axios": "^1.6.8",
     "dayjs": "^1.11.11",
+    "mitt": "^3.0.1",
     "next": "14.1.1",
     "react": "^18",
     "react-dom": "^18"

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,4 +1,9 @@
 import axios from "axios";
+import mitt from "mitt";
+
+import { authStorage } from "@/utils/webStorage";
+
+export const emitter = mitt();
 
 export const api = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_API_URL}`,
@@ -10,7 +15,12 @@ api.interceptors.response.use(
     return res;
   },
   (error) => {
-    console.error(error);
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 401) {
+        authStorage.remove();
+        emitter.emit("unAuthorized");
+      }
+    }
     return Promise.reject(error);
   }
 );

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,9 +1,7 @@
 import axios from "axios";
-import mitt from "mitt";
 
+import { eventEmitter } from "@/utils/eventEmitter";
 import { authStorage } from "@/utils/webStorage";
-
-export const emitter = mitt();
 
 export const api = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_API_URL}`,
@@ -18,7 +16,7 @@ api.interceptors.response.use(
     if (axios.isAxiosError(error)) {
       if (error.response?.status === 401) {
         authStorage.remove();
-        emitter.emit("unAuthorized");
+        eventEmitter.emit("unAuthorized");
       }
     }
     return Promise.reject(error);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import "@/utils/common";
 import ReactQueryProvider from "@/reactQueryProvider";
 import ServiceWorkerProvider from "@/ServiceWorkerProvider";
 import { UserProvider } from "@/store/user";
+import NavigationHandler from "@/components/common/NavigationHandler";
 
 /** https://github.com/orioncactus/pretendard?tab=readme-ov-file#nextjs */
 const pretendard = localFont({
@@ -38,7 +39,10 @@ export default function RootLayout({
       <body className={pretendard.className}>
         <ReactQueryProvider>
           <ServiceWorkerProvider>
-            <UserProvider>{children}</UserProvider>
+            <UserProvider>
+              <NavigationHandler />
+              {children}
+            </UserProvider>
           </ServiceWorkerProvider>
         </ReactQueryProvider>
       </body>

--- a/src/components/common/NavigationHandler.tsx
+++ b/src/components/common/NavigationHandler.tsx
@@ -10,7 +10,7 @@ export default function NavigationHandler() {
 
   useEffect(() => {
     const goToSignIn = () => {
-      router.replace("signIn");
+      router.replace("/signIn");
     };
     eventEmitter.set("unAuthorized", goToSignIn);
     return () => {

--- a/src/components/common/NavigationHandler.tsx
+++ b/src/components/common/NavigationHandler.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { emitter } from "@/api/axios";
+
+export default function NavigationHandler() {
+  const router = useRouter();
+
+  const goToSignIn = () => {
+    router.replace("signIn");
+  };
+  emitter.on("unAuthorized", goToSignIn);
+
+  return null;
+}

--- a/src/components/common/NavigationHandler.tsx
+++ b/src/components/common/NavigationHandler.tsx
@@ -1,16 +1,21 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
-import { emitter } from "@/api/axios";
+import { eventEmitter } from "@/utils/eventEmitter";
 
 export default function NavigationHandler() {
   const router = useRouter();
 
-  const goToSignIn = () => {
-    router.replace("signIn");
-  };
-  emitter.on("unAuthorized", goToSignIn);
-
+  useEffect(() => {
+    const goToSignIn = () => {
+      router.replace("signIn");
+    };
+    eventEmitter.set("unAuthorized", goToSignIn);
+    return () => {
+      eventEmitter.delete("unAuthorized");
+    };
+  }, [router]);
   return null;
 }

--- a/src/utils/eventEmitter.ts
+++ b/src/utils/eventEmitter.ts
@@ -1,0 +1,45 @@
+import mitt, { Emitter } from "mitt";
+
+// 이벤트 종류 유니온 타입
+export type EventType = "unAuthorized"; // 필요시 '...' 추가
+
+// 이벤트 핸들러 타입
+export type EventHandler = (payload?: unknown) => void;
+
+const emitter: Emitter<Record<EventType, unknown>> =
+  mitt<Record<EventType, unknown>>();
+const handlers: Map<EventType, Set<EventHandler>> = new Map();
+
+export const eventEmitter = {
+  set(event: EventType, handler: EventHandler) {
+    this.delete(event);
+    emitter.on(event, handler);
+    if (!handlers.has(event)) {
+      handlers.set(event, new Set());
+    }
+    handlers.get(event)!.add(handler);
+  },
+  get(event: EventType): Set<EventHandler> | undefined {
+    return handlers.get(event);
+  },
+  delete(event: EventType) {
+    const hs = handlers.get(event);
+    if (hs) {
+      hs.forEach((handler) => {
+        emitter.off(event, handler);
+      });
+      handlers.delete(event);
+    }
+  },
+  emit(event: EventType, data?: unknown) {
+    emitter.emit(event, data);
+  },
+  clear() {
+    handlers.forEach((hs, event) => {
+      hs.forEach((handler) => {
+        emitter.off(event, handler);
+      });
+    });
+    handlers.clear();
+  },
+};

--- a/src/utils/eventEmitter.ts
+++ b/src/utils/eventEmitter.ts
@@ -1,10 +1,8 @@
 import mitt, { Emitter } from "mitt";
 
-// 이벤트 종류 유니온 타입
-export type EventType = "unAuthorized"; // 필요시 '...' 추가
+type EventType = "unAuthorized";
 
-// 이벤트 핸들러 타입
-export type EventHandler = (payload?: unknown) => void;
+type EventHandler = (payload?: unknown) => void;
 
 const emitter: Emitter<Record<EventType, unknown>> =
   mitt<Record<EventType, unknown>>();


### PR DESCRIPTION
## 구현한 내용
401 에러가 발생할 경우 axios interceptor 에서 에러를 캐치해 emit 이벤트를 전역을 던집니다.
layout.tsx의 NaviagationHandler에서 해당 이벤트를 받아 `/signIn` 페이지로 리다이렉트합니다.

## 관련된 이슈
Close #154 